### PR TITLE
Use python3.10 for snyk

### DIFF
--- a/.github/workflows/python-sast.yaml
+++ b/.github/workflows/python-sast.yaml
@@ -88,7 +88,7 @@ jobs:
   snyk:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    container: "snyk/snyk:python"
+    container: "snyk/snyk:python-3.10"
 
     env:
       SNYK_INTEGRATION_NAME: GITHUB_ACTIONS


### PR DESCRIPTION
Python builds fail because of Snyk using Python 3.12: https://github.com/wayke-se/cms-service/actions/runs/6391286151/job/17347317322?pr=591