### PR TITLE
Feature/ghas migration

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -22,7 +22,7 @@ on:
       registry-password:
         required: true
       snyk-token:
-        required: true
+        required: false
     outputs:
       image:
         value: ${{ jobs.dockerize.outputs.image }}
@@ -70,4 +70,3 @@ jobs:
     secrets:
       registry-username: ${{ secrets.registry-username }}
       registry-password: ${{ secrets.registry-password }}
-      snyk-token: ${{ secrets.snyk-token }}

--- a/.github/workflows/docker-sast.yaml
+++ b/.github/workflows/docker-sast.yaml
@@ -16,8 +16,8 @@ on:
       registry-password:
         required: true
       snyk-token:
-        required: true
-
+        required: false
+          
 name: "Run SAST for Docker image"
 
 jobs:
@@ -36,38 +36,14 @@ jobs:
         password: ${{ secrets.registry-password }}
 
     - name: Run Grype to check Docker image for vulnerabilities
+      id: grype_scan
       uses: anchore/scan-action@v3
       with:
         image: ${{ inputs.registry-url }}/${{ inputs.image }}
         severity-cutoff: high
-        output-format: table
+        output-format: sarif
 
-  snyk:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    container: "snyk/snyk:docker"
-
-    env:
-      SNYK_INTEGRATION_NAME: GITHUB_ACTIONS
-      SNYK_INTEGRATION_VERSION: docker
-      SNYK_TOKEN: "${{ secrets.snyk-token }}"
-
-    permissions:
-      actions: read
-      contents: read
-      statuses: read
-      security-events: write
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Connect to Azure Container Registry
-      uses: docker/login-action@v3
+    - name: upload Anchore scan SARIF report
+      uses: github/codeql-action/upload-sarif@v2
       with:
-        registry: ${{ inputs.registry-url }}
-        username: ${{ secrets.registry-username }}
-        password: ${{ secrets.registry-password }}
-
-    - name: Run Snyk to check for vulnerabilities
-      run: |
-        snyk container test --severity-threshold=medium --file="${{ inputs.dockerfile }}" --policy-path=".snyk" "${{ inputs.registry-url }}/${{ inputs.image }}"
+        sarif_file: ${{ steps.grype_scan.outputs.sarif }}

--- a/.github/workflows/dotnet-build.yaml
+++ b/.github/workflows/dotnet-build.yaml
@@ -14,11 +14,11 @@ on:
       snyk-test:
         type: boolean
         required: false
-        default: true
+        default: false
       snyk-code:
         type: boolean
         required: false
-        default: true
+        default: false
       context:
         type: string
         required: false
@@ -35,7 +35,7 @@ on:
       nuget-token:
         required: false
       snyk-token:
-        required: true
+        required: false
     outputs:
       image:
         value: ${{ jobs.build-docker-image.outputs.image }}
@@ -47,11 +47,8 @@ jobs:
     uses: ./.github/workflows/dotnet-sast.yaml
     with:
       dotnet-version: ${{ inputs.dotnet-version }}
-      snyk-test: ${{ inputs.snyk-test }}
-      snyk-code: ${{ inputs.snyk-code }}
     secrets:
       nuget-token: ${{ secrets.nuget-token }}
-      snyk-token: ${{ secrets.snyk-token }}
 
   build-docker-image:
     runs-on: ubuntu-latest
@@ -120,4 +117,3 @@ jobs:
     secrets:
       registry-username: ${{ secrets.registry-username }}
       registry-password: ${{ secrets.registry-password }}
-      snyk-token: ${{ secrets.snyk-token }}

--- a/.github/workflows/dotnet-sast.yaml
+++ b/.github/workflows/dotnet-sast.yaml
@@ -7,16 +7,16 @@ on:
       snyk-test:
         type: boolean
         required: false
-        default: true
+        default: false
       snyk-code:
         type: boolean
         required: false
-        default: true
+        default: false
     secrets:
       nuget-token:
         required: false
       snyk-token:
-        required: true
+        required: false
 
 name: "Run SAST for .NET"
 
@@ -46,40 +46,3 @@ jobs:
           RESULT=$(dotnet list package --vulnerable --include-transitive)
           echo "${RESULT}"
           test $(echo "${RESULT}" | grep -cm 1 "following vulnerable packages") -ne 1
-
-  snyk:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    container: "snyk/snyk:dotnet"
-
-    env:
-      SNYK_INTEGRATION_NAME: GITHUB_ACTIONS
-      SNYK_INTEGRATION_VERSION: dotnet
-      SNYK_TOKEN: "${{ secrets.snyk-token }}"
-
-    permissions:
-      actions: read
-      contents: read
-      statuses: read
-      security-events: write
-
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Configure NuGet for private packages
-        run: |
-          [ ! -z "${{ secrets.nuget-token }}" ] && dotnet nuget update source "wayke-gh" --store-password-in-clear-text --configfile NuGet.Config -u "ourbjorn" -p "${{ secrets.nuget-token }}" || true
-
-      - name: Download dependencies
-        run: |
-          dotnet restore
-      
-      - name: Run Snyk to check for vulnerabilities
-        if: ${{ inputs.snyk-test }}
-        run: |
-          snyk test --file=$(find . -name '*.sln') --severity-threshold=high --policy-path=".snyk"
-
-      - name: Run Snyk to check for code security issues
-        if: ${{ inputs.snyk-code }}
-        run: |
-          snyk code test --file=$(find . -name '*.sln') --severity-threshold=high --policy-path=".snyk"

--- a/.github/workflows/golang-build.yaml
+++ b/.github/workflows/golang-build.yaml
@@ -14,11 +14,11 @@ on:
       snyk-test:
         type: boolean
         required: false
-        default: true
+        default: false
       snyk-code:
         type: boolean
         required: false
-        default: true
+        default: false
       context:
         type: string
         required: false
@@ -35,7 +35,7 @@ on:
       go-token:
         required: false
       snyk-token:
-        required: true
+        required: false
     outputs:
       image:
         value: ${{ jobs.build-docker-image.outputs.image }}
@@ -47,11 +47,8 @@ jobs:
     uses: ./.github/workflows/golang-sast.yaml
     with:
       go-version: ${{ inputs.go-version }}
-      snyk-test: ${{ inputs.snyk-test }}
-      snyk-code: ${{ inputs.snyk-code }}
     secrets:
       go-token: ${{ secrets.go-token }}
-      snyk-token: ${{ secrets.snyk-token }}
 
   build-docker-image:
     runs-on: ubuntu-latest
@@ -120,4 +117,3 @@ jobs:
     secrets:
       registry-username: ${{ secrets.registry-username }}
       registry-password: ${{ secrets.registry-password }}
-      snyk-token: ${{ secrets.snyk-token }}

--- a/.github/workflows/golang-sast.yaml
+++ b/.github/workflows/golang-sast.yaml
@@ -7,16 +7,16 @@ on:
       snyk-test:
         type: boolean
         required: false
-        default: true
+        default: false
       snyk-code:
         type: boolean
         required: false
-        default: true
+        default: false
     secrets:
       go-token:
         required: false
       snyk-token:
-        required: true
+        required: false
 
 name: "Run SAST for Go"
 
@@ -130,36 +130,3 @@ jobs:
       run: |
         go install golang.org/x/vuln/cmd/govulncheck@latest
         govulncheck ./...
-
-  snyk:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    container: "snyk/snyk:golang"
-
-    env:
-      SNYK_INTEGRATION_NAME: GITHUB_ACTIONS
-      SNYK_INTEGRATION_VERSION: golang
-      SNYK_TOKEN: "${{ secrets.snyk-token }}"
-
-    permissions:
-      actions: read
-      contents: read
-      statuses: read
-      security-events: write
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Configure git for private modules
-      run: |
-        [ ! -z "${{ secrets.go-token }}" ] && git config --global url."https://${{ secrets.go-token }}@github.com".insteadOf "https://github.com" || true
-
-    - name: Run Snyk to check for vulnerabilities
-      if: ${{ inputs.snyk-test }}
-      run: |
-        GOFLAGS="-buildvcs=false" snyk test --severity-threshold=high --policy-path=".snyk"
-
-    - name: Run Snyk to check for code security issues
-      if: ${{ inputs.snyk-code }}
-      run: |
-        GOFLAGS="-buildvcs=false" snyk code test --severity-threshold=high --policy-path=".snyk"

--- a/.github/workflows/node-sast.yaml
+++ b/.github/workflows/node-sast.yaml
@@ -6,7 +6,7 @@ on:
         required: true
     secrets:
       snyk-token:
-        required: true
+        required: false
 
 name: "Run SAST for NodeJS"
 
@@ -30,39 +30,3 @@ jobs:
       - name: Run npm audit
         run: |
           npm audit --audit-level high --package-lock-only --omit=dev
-
-  snyk:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    container: "snyk/snyk:dotnet"
-
-    env:
-      SNYK_INTEGRATION_NAME: GITHUB_ACTIONS
-      SNYK_INTEGRATION_VERSION: node
-      SNYK_TOKEN: "${{ secrets.snyk-token }}"
-
-    permissions:
-      actions: read
-      contents: read
-      statuses: read
-      security-events: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Use Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ inputs.node-version }}
-          registry-url: 'https://npm.pkg.github.com'
-      
-      - name: Install dependencies
-        run: npm ci --ignore-scripts --force
-      
-      - name: Run Snyk to check for vulnerabilities
-        run: |
-          snyk test --file=package.json --severity-threshold=high --policy-path=".snyk"
-
-      - name: Run Snyk to check for code security issues
-        run: |
-          snyk code test --file=package.json --severity-threshold=high --policy-path=".snyk"

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -18,18 +18,18 @@ on:
       snyk-test:
         type: boolean
         required: false
-        default: true
+        default: false
       snyk-code:
         type: boolean
         required: false
-        default: true
+        default: false
     secrets:
       registry-username:
         required: true
       registry-password:
         required: true
       snyk-token:
-        required: true
+        required: false
     outputs:
       image:
         value: ${{ jobs.dockerize.outputs.image }}
@@ -42,10 +42,6 @@ jobs:
     with:
       python-version: ${{ inputs.python-version }}
       requirements-file: ${{ inputs.requirements-file }}
-      snyk-test: ${{ inputs.snyk-test }}
-      snyk-code: ${{ inputs.snyk-code }}
-    secrets:
-      snyk-token: ${{ secrets.snyk-token }}
 
   dockerize:
     needs:
@@ -91,4 +87,3 @@ jobs:
     secrets:
       registry-username: ${{ secrets.registry-username }}
       registry-password: ${{ secrets.registry-password }}
-      snyk-token: ${{ secrets.snyk-token }}

--- a/.github/workflows/python-sast.yaml
+++ b/.github/workflows/python-sast.yaml
@@ -11,16 +11,16 @@ on:
       snyk-test:
         type: boolean
         required: false
-        default: true
+        default: false
       snyk-code:
         type: boolean
         required: false
-        default: true
+        default: false
     secrets:
       nuget-token:
         required: false
       snyk-token:
-        required: true
+        required: false
 
 name: "Run SAST for Python"
 
@@ -84,36 +84,3 @@ jobs:
       - name: Run pre-commit
         run: |
           pre-commit run --show-diff-on-failure --color=always --all-files
-
-  snyk:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    container: "snyk/snyk:python-3.10"
-
-    env:
-      SNYK_INTEGRATION_NAME: GITHUB_ACTIONS
-      SNYK_INTEGRATION_VERSION: python
-      SNYK_TOKEN: "${{ secrets.snyk-token }}"
-
-    permissions:
-      actions: read
-      contents: read
-      statuses: read
-      security-events: write
-
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Download dependencies
-        run: |
-          pip install -r ${{ inputs.requirements-file}}
-      
-      - name: Run Snyk to check for vulnerabilities
-        if: ${{ inputs.snyk-test }}
-        run: |
-          snyk test --all-projects --severity-threshold=high --policy-path=".snyk"
-
-      - name: Run Snyk to check for code security issues
-        if: ${{ inputs.snyk-code }}
-        run: |
-          snyk code test --all-projects --severity-threshold=high --policy-path=".snyk"


### PR DESCRIPTION
Vi lämnar snyk för Github Advanced Security (GHAS)

I och med detta plockar vi bort allt som har med snyk att göra, och ser till att alla våra scanningar rapporterar korrekt till GHAS via sarif eller liknande.

- [x] Docker SAST: ta bort snyk
- [x] DotNet SAST: ta bort snyk
- [x] GoLang SAST: ta bort snyk
- [x] Node SAST: ta bort snyk
- [x] Python SAST: ta bort snyk
