### PR TITLE
fix(blue-green): drain old deployment before deleting it

### DIFF
--- a/.github/actions/k8s/blue-green-deploy/entrypoint.sh
+++ b/.github/actions/k8s/blue-green-deploy/entrypoint.sh
@@ -141,9 +141,17 @@ kubectl patch svc/"${APP_NAME}" --patch "$(cat "${PATCH_FILE}")"
 
 ###
 # If we had an active deployment before this release,
-# clean it up
+# clean it up.
+#
+# Wait before deleting: the Service selector patch above moves
+# traffic to the new pods, but ingress controllers pick up the
+# new endpoints asynchronously. Deleting the old deployment
+# immediately kills all its pods at once, which surfaces as
+# intermittent 502s (Cloudflare "host error") on every deploy.
 ###
 if [ ! -z "${PREVIOUS_VERSIONS}" ]; then
+    sleep 10
+
     for deploy in ${PREVIOUS_VERSIONS}; do
         kubectl delete deploy "${deploy}"
     done


### PR DESCRIPTION
intent(blue-green): intermittent Cloudflare host-error pages on dealer.wayke.se traced to deploys - old pods were deleted seconds after the service selector patch, before ingress-nginx had synced its upstream endpoints, so nginx hit connection refused on every upstream and returned 502
decision(blue-green): fixed 10s sleep - nginx endpoint sync takes ~1-2s, and in-flight requests on old pods are covered by Next.js graceful shutdown within terminationGracePeriod
rejected(blue-green): programmatically verifying the endpoint sync - far more complexity for a delay that in practice never exceeds a couple of seconds
constraint(blue-green): all consumers pin this action at master (dealer-ui, web-ui, web-ui-v2 in both test and prod), so the change is live everywhere on their next deploy - kept strictly additive for that reason

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wayke-se/codesmith/ci/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789886442&installation_model_id=424954&pr_number=81&repository=wayke-se%2Fci&return_to=https%3A%2F%2Fgithub.com%2Fwayke-se%2Fci%2Fpull%2F81&signature=70be31f4277bb498357289a5a3ab286681332ebc38c109147c99a95cad6d9596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->